### PR TITLE
Check for overlapping chains and repeating bonds

### DIFF
--- a/polychrom/forcekits.py
+++ b/polychrom/forcekits.py
@@ -31,7 +31,7 @@ def polymer_chains(
     nonbonded_force_func=forces.polynomial_repulsive,
     nonbonded_force_kwargs={"trunc": 3.0, "radiusMult": 1.0},
     except_bonds=True,
-    force=False
+    override_checks=False
 ):
     """Adds harmonic bonds connecting polymer chains
 
@@ -48,7 +48,7 @@ def polymer_chains(
         If True then do not calculate non-bonded forces between the
         particles connected by a bond. True by default.
     
-    force: bool
+    override_checks: bool
         If True then do not check that all monomers are a member of exactly
         one chain. False by default.
     """
@@ -72,7 +72,7 @@ def polymer_chains(
             triplets.append((int(end - 1), int(start), int(start + 1)))
     
     # check that all monomers are a member of exactly one chain
-    if not force:
+    if not override_checks:
         num_chains_for_monomer = [0] * sim_object.N
         for chain in newchains:
             start, end, _ = chain
@@ -81,7 +81,7 @@ def polymer_chains(
         
         for i in range(sim_object.N):
             if num_chains_for_monomer[i] != 1:
-                raise Exception(f'Monomer {i} is a member of {num_chains_for_monomer[i]} chains. Set force=True to override this check.')
+                raise Exception(f'Monomer {i} is a member of {num_chains_for_monomer[i]} chains. Set override_checks=True to override this check.')
 
     report_dict = {
         "chains": np.array(newchains, dtype=int),

--- a/polychrom/forcekits.py
+++ b/polychrom/forcekits.py
@@ -50,7 +50,10 @@ def polymer_chains(
     
     override_checks: bool
         If True then do not check that all monomers are a member of exactly
-        one chain. False by default.
+        one chain. False by default. Note that overriding checks does not
+        get automatically "passed on" to bond/angle force functions so you
+        may need to specify override_checks=True in the respective kwargs
+        as well.
     """
 
     force_list = []
@@ -81,7 +84,7 @@ def polymer_chains(
         
         for i in range(sim_object.N):
             if num_chains_for_monomer[i] != 1:
-                raise Exception(f'Monomer {i} is a member of {num_chains_for_monomer[i]} chains. Set override_checks=True to override this check.')
+                raise ValueError(f'Monomer {i} is a member of {num_chains_for_monomer[i]} chains. Set override_checks=True to override this check.')
 
     report_dict = {
         "chains": np.array(newchains, dtype=int),

--- a/polychrom/forcekits.py
+++ b/polychrom/forcekits.py
@@ -76,15 +76,14 @@ def polymer_chains(
     
     # check that all monomers are a member of exactly one chain
     if not override_checks:
-        num_chains_for_monomer = [0] * sim_object.N
+        num_chains_for_monomer = np.zeros(sim_object.N, dtype=int)
         for chain in newchains:
             start, end, _ = chain
-            for i in range(start, end):
-                num_chains_for_monomer[i] += 1
+            num_chains_for_monomer[start:end] += 1
         
-        for i in range(sim_object.N):
-            if num_chains_for_monomer[i] != 1:
-                raise ValueError(f'Monomer {i} is a member of {num_chains_for_monomer[i]} chains. Set override_checks=True to override this check.')
+        errs = np.where(num_chains_for_monomer != 1)[0]
+        if len(errs) != 0:
+            raise ValueError(f'Monomer {errs[0]} is a member of {num_chains_for_monomer[errs[0]]} chains. Set override_checks=True to override this check.')
 
     report_dict = {
         "chains": np.array(newchains, dtype=int),

--- a/polychrom/forces.py
+++ b/polychrom/forces.py
@@ -90,7 +90,7 @@ def _to_array_1d(scalar_or_array, arrlen, dtype=float):
 
 
 def harmonic_bonds(
-    sim_object, bonds, bondWiggleDistance=0.05, bondLength=1.0, name="harmonic_bonds",
+    sim_object, bonds, bondWiggleDistance=0.05, bondLength=1.0, name="harmonic_bonds", override_checks=False
 ):
     """Adds harmonic bonds
 
@@ -106,11 +106,22 @@ def harmonic_bonds(
     bondLength : float or iterable of float
         The length of the bond.
         Can be provided per-particle.
+    override_checks: bool
+        If True then do not check that no bonds are repeated.
+        False by default.
     """
 
     force = openmm.HarmonicBondForce()
     force.name = name
+    
+    # check for repeating bond
+    if not override_checks:
+        if len(set(bonds)) != len(bonds):
+            for bond in set(bonds):
+                bonds.remove(bond)
 
+            raise Exception(f'Bond {bonds[0]} is repeated. Set override_checks=True to override this check.')
+    
     bondLength = _to_array_1d(bondLength, len(bonds)) * sim_object.length_scale
     bondWiggleDistance = (
         _to_array_1d(bondWiggleDistance, len(bonds)) * sim_object.length_scale

--- a/polychrom/forces.py
+++ b/polychrom/forces.py
@@ -79,12 +79,9 @@ def _check_bonds(bonds, N):
 
     # check that all monomers make at least one bond
     monomer_not_in_bond = ~np.zeros(N).astype(bool)
-    for bond in bonds:
-        monomer_not_in_bond[bond[0]] = False
-        monomer_not_in_bond[bond[1]] = False
-
+    monomer_not_in_bond[np.array(bonds).reshape(-1)] = False
     if monomer_not_in_bond.any():
-        raise ValueError(f'Monomers {np.where(monomer_not_in_bond)} are not in any bonds. Set override_checks=True to override this check.')
+        raise ValueError(f'Monomers {np.where(monomer_not_in_bond)[0]} are not in any bonds. Set override_checks=True to override this check.')
 
 def _check_angle_bonds(triplets):
     # check that triplets are unique

--- a/polychrom/forces.py
+++ b/polychrom/forces.py
@@ -79,9 +79,15 @@ def _check_bonds(bonds, N):
 
     # check that all monomers make at least one bond
     monomer_not_in_bond = ~np.zeros(N).astype(bool)
-    monomer_not_in_bond[np.array(bonds).reshape(-1)] = False
+    bonds_arr = np.array(bonds)
+    monomer_not_in_bond[bonds_arr.reshape(-1)] = False
     if monomer_not_in_bond.any():
         raise ValueError(f'Monomers {np.where(monomer_not_in_bond)[0]} are not in any bonds. Set override_checks=True to override this check.')
+        
+    # check that no bonds of the form (i, i) exist
+    if (bonds_arr[:, 0] == bonds_arr[:, 1]).any():
+        index = np.where(bonds_arr[:, 0] == bonds_arr[:, 1])[0]
+        raise ValueError(f'Bonds {bonds_arr[index].tolist()} are self-bonds. Set override_checks=True to override this check.')
 
 def _check_angle_bonds(triplets):
     # check that triplets are unique
@@ -90,6 +96,16 @@ def _check_angle_bonds(triplets):
             triplets.remove(triplet)
 
         raise ValueError(f'Triplets {triplets} are repeated. Set override_checks=True to override this check.')
+    
+    # check that no triplet of the form (i, i, j) exists
+    # check that no bonds of the form (i, i) exist
+    triplet_arr = np.array(triplets)
+    err_condition = (triplet_arr[:, 0] == triplet_arr[:, 1]) | (triplet_arr[:, 0] == triplet_arr[:, 2]) | \
+        (triplet_arr[:, 1] == triplet_arr[:, 2])
+    if err_condition.any():
+        index = np.where(err_condition)[0]
+        raise ValueError(f'Triplets {triplet_arr[index].tolist()} contain monomers with the same index. Set override_checks=True to override this check.')
+
         
 def _to_array_1d(scalar_or_array, arrlen, dtype=float):
     """


### PR DESCRIPTION
Fixes #21.

If invalid chains (i.e. a monomer in 0 chains or multiple chains) are used in `polychrom.forcekits.polymer_chains`, e.g.:

    sim.add_force(polychrom.forcekits.polymer_chains(sim, chains=[(0, 11, 0), (10, None, 1)]))

then the program will raise an exception:

    ValueError: Monomer 10 is a member of 2 chains. Set override_checks=True to override this check.

It also checks in bond forces in `polychrom.forces` that:

* all monomers make at least one bond
* no bond is repeated

And in angle forces that:

* no triplet is repeated

E.g.:

    sim.add_force(polychrom.forces.harmonic_bonds(sim, [(k, k+1) for k in range(0,999)] + [(1, 2)]))
    ...
    ValueError: Bonds [(1, 2)] are repeated. Set override_checks=True to override this check.

The checks can by overridden by passing `override_checks=True` to any function that uses  checks.